### PR TITLE
Refactor Dockerfile: Simplify build process and expose ports

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,0 +1,16 @@
+# Use the Ballerina base image to start with
+FROM ballerina/ballerina:latest
+
+# Set the working directory inside the container
+WORKDIR /app
+
+COPY /Backend /app/
+RUN ls -la /app/
+RUN bal version
+
+EXPOSE 8080
+EXPOSE 21003
+
+RUN bal build
+
+CMD ["bal", "run"]


### PR DESCRIPTION
This pull request refactors the Dockerfile to simplify the build process and expose ports. The changes include using the Ballerina base image, setting the working directory, copying the backend files, exposing ports 8080 and 21003, building the project, and running the application.